### PR TITLE
Allow audit schema names up to 30 characters

### DIFF
--- a/audit_util_pb.sql
+++ b/audit_util_pb.sql
@@ -8,7 +8,7 @@ IS
 --
 -- global vars for new audit table support
 --
-  g_aud_schema      constant varchar2(10)  := upper('&&schema');
+  g_aud_schema      constant varchar2(30)  := upper('&&schema');
   g_aud_tspace      constant varchar2(30)  := '&&tspace';
   
   -- prefix for all audit table names

--- a/same_schema/audit_util_pb.sql
+++ b/same_schema/audit_util_pb.sql
@@ -9,7 +9,7 @@ IS
 --
 -- global vars for new audit table support
 --
-  g_aud_schema      constant varchar2(10)  := upper('&&schema');
+  g_aud_schema      constant varchar2(30)  := upper('&&schema');
   g_aud_tspace      constant varchar2(30)  := '&&tspace';
   
   -- prefix for all audit table names


### PR DESCRIPTION
Hi Connor,

I had an issue to install the audit utility in a schema with a name longer then 10 characters. I assume that the intention was to have here 30 characters and the current value of 10 characters are the result of some copy/paste thing...

Best regards
Ottmar
