### PR TITLE
suppress creation of header entries if g_inserts_audited = false

### DIFF
--- a/audit_util_pb.sql
+++ b/audit_util_pb.sql
@@ -945,10 +945,16 @@ BEGIN
   bld('    end;');
 
   bld(' ');
-  if g_bulk_bind then      
-    bld('  '||lower(g_aud_schema)||'.audit_pkg.log_header_bulk('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
-  else
-    bld('  '||lower(g_aud_schema)||'.audit_pkg.log_header('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+  if not g_inserts_audited then
+    bld('  if l_dml != ''I'' then ');
+  end if;
+    if g_bulk_bind then
+      bld('    '||lower(g_aud_schema)||'.audit_pkg.log_header_bulk('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+    else
+      bld('    '||lower(g_aud_schema)||'.audit_pkg.log_header('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+    end if;
+  if not g_inserts_audited then
+    bld('  end if;');
   end if;
   bld(' ');
 

--- a/same_schema/audit_util_pb.sql
+++ b/same_schema/audit_util_pb.sql
@@ -952,10 +952,16 @@ BEGIN
   bld('    end;');
 
   bld(' ');
-  if g_bulk_bind then      
-    bld('  '||lower(g_aud_schema)||'.&&prefix.audit_pkg.log_header_bulk('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
-  else
-    bld('  '||lower(g_aud_schema)||'.&&prefix.audit_pkg.log_header('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+  if not g_inserts_audited then
+    bld('  if l_dml != ''I'' then ');
+  end if;
+    if g_bulk_bind then
+      bld('    '||lower(g_aud_schema)||'.&&prefix.audit_pkg.log_header_bulk('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+    else
+      bld('    '||lower(g_aud_schema)||'.&&prefix.audit_pkg.log_header('''||upper(p_table_name)||''',l_dml,l_descr,l_tstamp,l_id);');
+    end if;
+  if not g_inserts_audited then
+    bld('  end if;');
   end if;
   bld(' ');
 


### PR DESCRIPTION
Hi Connor,

sorry for another pull request. Seems that audit header entries are created when g_inserts_audited is set to false. I think this was not your intention because these entries are useless without the detail information from the table.

Feel free to delete this pull request if I am wrong with my assumption or if you are not happy with the provided code.

Best regards
Ottmar