### PR TITLE
Changed data type to clob for longer code generation in generate_audi…

### DIFF
--- a/audit_util_pb.sql
+++ b/audit_util_pb.sql
@@ -116,16 +116,14 @@ end;
 --
 -- execute some DDL, as well as output it
 --
-procedure do_sql(p_sql varchar2,p_execute boolean) is
-  l_sql varchar2(32767) := p_sql;
+procedure do_sql(p_sql clob,p_execute boolean) is
+  l_offset int := 1;
 begin
-  while instr(l_sql,chr(10)) > 0 loop
-    dbms_output.put_line(substr(l_sql,1,instr(l_sql,chr(10))-1));
-    l_sql := substr(l_sql,instr(l_sql,chr(10))+1);
-  end loop;
-  if l_sql is not null then
-    dbms_output.put_line(l_sql);
-  end if;
+  while dbms_lob.instr(p_sql, chr(10), l_offset, 1) > 0 loop   
+    dbms_output.put_line(dbms_lob.substr(p_sql, dbms_lob.instr(p_sql, chr(10), l_offset, 1)-1, l_offset));  
+    l_offset := dbms_lob.instr(p_sql, chr(10), l_offset, 1)+1;  
+  end loop;    
+  dbms_output.put_line(dbms_lob.substr(p_sql, dbms_lob.getlength(p_sql), l_offset)); 
 
   if p_execute then
     execute immediate p_sql;
@@ -614,7 +612,7 @@ PROCEDURE generate_audit_package(p_owner varchar2
   type col_list is table of col_defn%rowtype;
   cols col_list;
 
-  l_ddl   varchar2(32767);
+  l_ddl   clob;
 
   procedure bld(p_sql varchar2) is
   begin

--- a/v2/audit_util_pb.sql
+++ b/v2/audit_util_pb.sql
@@ -186,16 +186,14 @@ end;
 --
 -- execute some DDL, as well as output it
 --
-procedure do_sql(p_sql varchar2,p_execute boolean) is
-  l_sql varchar2(32767) := p_sql;
+procedure do_sql(p_sql clob,p_execute boolean) is
+  l_offset int := 1;
 begin
-  while instr(l_sql,chr(10)) > 0 loop
-    dbms_output.put_line(substr(l_sql,1,instr(l_sql,chr(10))-1));
-    l_sql := substr(l_sql,instr(l_sql,chr(10))+1);
-  end loop;
-  if l_sql is not null then
-    dbms_output.put_line(l_sql);
-  end if;
+  while dbms_lob.instr(p_sql, chr(10), l_offset, 1) > 0 loop   
+    dbms_output.put_line(dbms_lob.substr(p_sql, dbms_lob.instr(p_sql, chr(10), l_offset, 1)-1, l_offset));  
+    l_offset := dbms_lob.instr(p_sql, chr(10), l_offset, 1)+1;  
+  end loop;    
+  dbms_output.put_line(dbms_lob.substr(p_sql, dbms_lob.getlength(p_sql), l_offset)); 
 
   if p_execute then
     execute immediate p_sql;
@@ -729,7 +727,7 @@ PROCEDURE generate_audit_package(p_owner varchar2
   type col_list is table of col_defn%rowtype;
   cols col_list;
 
-  l_ddl   varchar2(32767);
+  l_ddl   clob;
 
   procedure bld(p_sql varchar2) is
   begin


### PR DESCRIPTION
Hi Connor,

I had an issue enabling audit support with "generate_audit_support" for some tables with more than 50 columns. I had to change the varchar2 to clob for code generation, here is what I did.

The error was as below.

```
Erro a partir da linha : 1 no comando -
begin
    SCM_AUDIT_SOO.audit_util.generate_audit_support(
        p_owner => 'SCM_DATA_SOO', 
        p_table_name => 'SOO_CATEGORIA_MMMMAMMM', 
        p_action => 'EXECUTE',
        p_partitioning => 'Y',
        p_inserts_audited => 'Y',
        p_audit_lobs_on_update_always => 'N'
    );
end;
Relatório de erros -
ORA-06502: PL/SQL: erro: buffer de string de caracteres pequeno demais numérico ou de valor
ORA-06512: em "SCM_AUDIT_SOO.AUDIT_UTIL", line 733
ORA-06512: em "SCM_AUDIT_SOO.AUDIT_UTIL", line 1009
ORA-06512: em "SCM_AUDIT_SOO.AUDIT_UTIL", line 1523
ORA-06512: em line 2
06502. 00000 -  "PL/SQL: numeric or value error%s"
*Cause:    An arithmetic, numeric, string, conversion, or constraint error
           occurred. For example, this error occurs if an attempt is made to
           assign the value NULL to a variable declared NOT NULL, or if an
           attempt is made to assign an integer larger than 99 to a variable
           declared NUMBER(2).
*Action:   Change the data, how it is manipulated, or how it is declared so
           that values do not violate constraints.
```

